### PR TITLE
copy `i18n` to `I18n`

### DIFF
--- a/rails-webpacker/app/javascript/controllers/hello_controller.ts
+++ b/rails-webpacker/app/javascript/controllers/hello_controller.ts
@@ -10,13 +10,12 @@
 import { Controller } from "stimulus";
 import { i18n } from "config/i18n";
 
-const { t } = i18n;
-
 export default class extends Controller {
   static targets = ["output"];
   outputTarget: HTMLHeadingElement;
 
   connect() {
-    this.outputTarget.textContent = t("hello");
+    const I18n = i18n; //in order to allow i18n-tasks to correctly scan and pick up translation strings
+    this.outputTarget.textContent = I18n.t("hello");
   }
 }

--- a/rails-webpacker/app/javascript/controllers/hello_controller.ts
+++ b/rails-webpacker/app/javascript/controllers/hello_controller.ts
@@ -10,11 +10,13 @@
 import { Controller } from "stimulus";
 import { i18n } from "config/i18n";
 
+const { t } = i18n;
+
 export default class extends Controller {
   static targets = ["output"];
   outputTarget: HTMLHeadingElement;
 
   connect() {
-    this.outputTarget.textContent = i18n.t("hello");
+    this.outputTarget.textContent = t("hello");
   }
 }


### PR DESCRIPTION
`i18n-tasks add-missing` will only work for `I18n.t()` or `t()`, not for `i18n.t()`